### PR TITLE
Small changes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Eagle CLI
 The Eagle Genomics Command Line Interface (CLI) is a tool for interacting with the different Eagle APIs and instances from the command line / shell of various operating systems. Hereforth refered to as eagle_cli
 
-It is written in Ruby. The tool is still very much a work in progress
+It is written in Ruby. The tool is still very much a work in progress.
 
 ### Testing
 
@@ -14,11 +14,11 @@ It is written in Ruby. The tool is still very much a work in progress
 
 ##### clone this repository and enter directory
 ```
-git clone git@github.com:EagleGenomics/data-layer-cli.git`
+git clone git@github.com:EagleGenomics/data-layer-cli.git
 cd data-layer-cli
 ```
 
-##### install dependencies, build and install gem
+##### Install dependencies, build and install gem
 ```
 bundler install
 gem build eagle_cli.gemspec
@@ -27,7 +27,7 @@ gem install eagle_cli-0.0.1.gem
 
 ### Usage
 You will be asked to enter your Eagle Instance credentials the first time you run a command; after the first time, credentials will be saved to ~/.eagle_cli for future use.
-It’s generally a good idea to login and add your credentials immediately after installing edlcli so that you can use it.
+It’s generally a good idea to login and add your credentials immediately after installing eagle_cli so that you can use it.
 
 ```
 eagle_cli configure
@@ -36,7 +36,7 @@ Instance url: https://demo.example.com/
 Client Id: *****************
 Client Secret: *****************
 ```
-You are now ready to execute your first command
+You are now ready to execute your first command.
 
 #### List Datapackages
 `eagle_cli list`
@@ -44,11 +44,11 @@ to list all available datapackages
 
 #### Download Datapackages
 `eagle_cli download PACKAGE_URL DOWNLOAD_DIR`
-to dowload a specific package
+to download a specific package
 
 #### Upload Datapackages [WIP]
 `eagle_cli upload PACKAGE_PATH`
-this command only accepts `.zip` or `.json` files according to the datapackage standard.
+this command only accepts `.zip` or `.json` files according to the [datapackage](http://frictionlessdata.io/data-packages/) standard.
 
 
 ## Development
@@ -56,6 +56,5 @@ this command only accepts `.zip` or `.json` files according to the datapackage s
 ### TODOs
 
 - Improve test coverage
-- Continious integration
+- Continuous integration
 - extract API wrapper to separate repo
-


### PR DESCRIPTION
Mostly typos and a stray ' which would have caused problems when copy-and-pasting commands.